### PR TITLE
allow custom processing of markdown content

### DIFF
--- a/bin/mdsh
+++ b/bin/mdsh
@@ -21,7 +21,7 @@
 
 set -euo pipefail  # Strict mode
 mdsh-parse() {
-	local cmd=$1 lno=0 block_start lang block ln indent fence close_fence indent_remove
+	local cmd=$1 lno=0 block_start lang block ln indent fence close_fence indent_remove md_block
 	local open_fence=$'^( {0,3})(~~~+|```+) *([^`]*)$'
 	while ((lno++)); IFS= read -r ln; do
 		if [[ $ln =~ $open_fence ]]; then
@@ -31,6 +31,11 @@ mdsh-parse() {
 				! [[ $ln =~ $indent_remove ]] || ln=${ln#${BASH_REMATCH[0]}}; block+=$ln$'\n'
 			done
 			lang="${lang%"${lang##*[![:space:]]}"}"; "$cmd" fenced "$lang" "$block";
+			# reset open md_block
+			md_block=
+		else
+			# accumulate md text
+			md_block+=$ln$'\n'
 		fi
 	done
 }
@@ -67,10 +72,13 @@ __COMPILE__() {
 		;;
 	*)  mdsh_lang=${2//[^_[:alnum:]]/_}  # convert entire line to safe variable name
 	esac
+	if fn-exists "mdsh-md-compile"; then
+		mdsh-md-compile "$md_block" "$lang"
+	fi
 	if fn-exists "mdsh-lang-$mdsh_lang"; then
 		mdsh-rewrite "mdsh-lang-$mdsh_lang" "{" "} <<'\`\`\`'"; printf $'%s```\n' "$3"
 	elif fn-exists "mdsh-compile-$mdsh_lang"; then
-		"mdsh-compile-$mdsh_lang" "$3" "$2" "$block_start"
+		"mdsh-compile-$mdsh_lang" "$3" "$2" "$block_start" "$md_block"
 	else
 		mdsh-misc "$2" "$3"
 	fi

--- a/mdsh.md
+++ b/mdsh.md
@@ -62,7 +62,7 @@ The `$fence` and `$indent` variables can be inspected to tell what the block's o
 
 ```shell
 mdsh-parse() {
-	local cmd=$1 lno=0 block_start lang block ln indent fence close_fence indent_remove
+	local cmd=$1 lno=0 block_start lang block ln indent fence close_fence indent_remove md_block
 	local open_fence=$'^( {0,3})(~~~+|```+) *([^`]*)$'
 	while ((lno++)); IFS= read -r ln; do
 		if [[ $ln =~ $open_fence ]]; then
@@ -72,6 +72,11 @@ mdsh-parse() {
 				! [[ $ln =~ $indent_remove ]] || ln=${ln#${BASH_REMATCH[0]}}; block+=$ln$'\n'
 			done
 			lang="${lang%"${lang##*[![:space:]]}"}"; "$cmd" fenced "$lang" "$block";
+			# reset open md_block
+			md_block=
+		else
+			# accumulate md text
+			md_block+=$ln$'\n'
 		fi
 	done
 }
@@ -135,10 +140,13 @@ __COMPILE__() {
 		;;
 	*)  mdsh_lang=${2//[^_[:alnum:]]/_}  # convert entire line to safe variable name
 	esac
+	if fn-exists "mdsh-md-compile"; then
+		mdsh-md-compile "$md_block" "$lang"
+	fi
 	if fn-exists "mdsh-lang-$mdsh_lang"; then
 		mdsh-rewrite "mdsh-lang-$mdsh_lang" "{" "} <<'\`\`\`'"; printf $'%s```\n' "$3"
 	elif fn-exists "mdsh-compile-$mdsh_lang"; then
-		"mdsh-compile-$mdsh_lang" "$3" "$2" "$block_start"
+		"mdsh-compile-$mdsh_lang" "$3" "$2" "$block_start" "$md_block"
 	else
 		mdsh-misc "$2" "$3"
 	fi


### PR DESCRIPTION
Stores markdown content between code blocks, and executes `mdsh-md-compile`
function (if defined) passing the markdown content and the language tag
of the following code block into it. The function is executed immediately
before the language hooks for the following code block.

Also, pass the markdown content as last parameter to the `mdsh-compile-lang`
function in case someone whats to us the content when generating
code (for example to add logging statements based on the content).

## Background

I have been working on "interactive" documentation, which can be hosted on github/gitbook and at the same time executed step by step form command line. I've written some custom compilation functions which allow me to interactively step through selected code blocks, display their content in the terminal, ask for user input if necessary and execute the code (if users chooses to do so). I wanted to be able display some additional information to the user who would be stepping through the code, and found that most of the time, the section of the markdown between the previous and current code blocks would contained the info necessary to understand whats happening.   

I am using [mdless](https://github.com/ttscoff/mdless) and [pygments](http://pygments.org/) to render the markdown and the code blocks.  

Here's an example `mdsh-md-compile` implementation displays all markdown content proceeding blocks using language other than `shell`:

```bash @mdsh
mdsh-md-compile() {
  if [ "$2" != "shell" ]; then
    printf "echo %q | mdless | cat\n" "$1"
  fi
}
```
