### PR TITLE
Add mdsh-find-block hook for parser customization

### DIFF
--- a/bin/mdsh
+++ b/bin/mdsh
@@ -22,17 +22,18 @@
 set -euo pipefail  # Strict mode
 mdsh-parse() {
 	local cmd=$1 lno=0 block_start lang mdsh_block ln indent fence close_fence indent_remove
-	local open_fence=$'^( {0,3})(~~~+|```+) *([^`]*)$'
-	while ((lno++)); IFS= read -r ln; do
-		if [[ $ln =~ $open_fence ]]; then
-			indent=${BASH_REMATCH[1]} fence=${BASH_REMATCH[2]} lang=${BASH_REMATCH[3]} mdsh_block=
-			block_start=$lno close_fence="^( {0,3})$fence+ *\$" indent_remove="^${indent// / ?}"
-			while ((lno++)); IFS= read -r ln && ! [[ $ln =~ $close_fence ]]; do
-				! [[ $ln =~ $indent_remove ]] || ln=${ln#${BASH_REMATCH[0]}}; mdsh_block+=$ln$'\n'
-			done
-			lang="${lang%"${lang##*[![:space:]]}"}"; "$cmd" fenced "$lang" "$mdsh_block"
-		fi
+	local mdsh_fence=$'^( {0,3})(~~~+|```+) *([^`]*)$'
+	while mdsh-find-block; do
+		indent=${BASH_REMATCH[1]} fence=${BASH_REMATCH[2]} lang=${BASH_REMATCH[3]} mdsh_block=
+		block_start=$lno close_fence="^( {0,3})$fence+ *\$" indent_remove="^${indent// / ?}"
+		while ((lno++)); IFS= read -r ln && ! [[ $ln =~ $close_fence ]]; do
+			! [[ $ln =~ $indent_remove ]] || ln=${ln#${BASH_REMATCH[0]}}; mdsh_block+=$ln$'\n'
+		done
+		lang="${lang%"${lang##*[![:space:]]}"}"; "$cmd" fenced "$lang" "$mdsh_block"
 	done
+}
+mdsh-find-block(){
+	while ((lno++)); IFS= read -r ln; do if [[ $ln =~ $mdsh_fence ]]; then return; fi; done; false
 }
 mdsh-source() {
 	local MDSH_FOOTER='' MDSH_SOURCE


### PR DESCRIPTION
An alternative approach to #5 - a function that parses markdown and can see the opening fence.